### PR TITLE
Fix bookmarking bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
       - run:
           name: 'Setup'
           command: |
+            apt-get install -y libsnappy-dev
             virtualenv -p python3 ~/.virtualenvs/tap-heap
             source ~/.virtualenvs/tap-heap/bin/activate
             pip install .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: 'Setup'
           command: |
-            apt-get install -y libsnappy-dev
+            sudo apt-get install -y libsnappy-dev
             virtualenv -p python3 ~/.virtualenvs/tap-heap
             source ~/.virtualenvs/tap-heap/bin/activate
             pip install .

--- a/README.md
+++ b/README.md
@@ -2,4 +2,15 @@
 
 ---
 
+
+# Installation
+
+Heap uses the Avro encoding by Apache with a compression algorithm called Snappy. To install this project, you'll need to install some dependencies:
+
+```
+$ apt-get install libsnappy-dev
+```
+
+Installing libsnappy-dev will allow the C libraries required by `python-snappy` and `fastavro` to install correctly via pip.
+
 Copyright &copy; 2018 Stitch


### PR DESCRIPTION
The `sorted` function was not sorting quite right based on the strings so we have to pull out the first two matched integers (calling them "sync_id" and "part_id") and use them to sort.

Also fixes the bookmark logic to drop the sorted files until after the index of the bookmark.