### PR TITLE
Handle case where there are no `incremental = false` dumps

### DIFF
--- a/tap_heap/sync.py
+++ b/tap_heap/sync.py
@@ -21,13 +21,16 @@ def filter_manifests_to_sync(manifests, table_name, state):
 
     full_table_dumps = [dump_id for dump_id, manifest in manifests.items()
                         if manifest.get(table_name, {}).get('incremental') is False]
-    last_full_table_dump = max(full_table_dumps)
 
     if bookmark and bookmarked_version:
-        minimum_dump_id_to_sync = max(last_full_table_dump, bookmarked_dump_id)
+        minimum_dump_id_to_sync = max([bookmarked_dump_id] + full_table_dumps)
         should_create_new_version = minimum_dump_id_to_sync != bookmarked_dump_id
     else:
-        minimum_dump_id_to_sync = last_full_table_dump
+        if len(full_table_dumps) > 0:
+            minimum_dump_id_to_sync = max(full_table_dumps)
+        else:
+            minimum_dump_id_to_sync = 0
+
         should_create_new_version = True
 
     # table_manifest[dump_id] = {"files" ["file 1"], "incremental": True, "columns": ["column_1"]}


### PR DESCRIPTION
# Description of change
If there are no `incremental=false` dumps for a table the tap should not crash.

# Manual QA steps
 - Ran this on a connection both with a bookmark and without.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
