### PR TITLE
Fix/errors missed during refactor

### DIFF
--- a/tap_heap/sync.py
+++ b/tap_heap/sync.py
@@ -53,8 +53,10 @@ def key_fn(key):
     This function returns a tuple: (int("852"), int("00000")
     """
 
-    matches = re.findall('([0-9]+)', key)
-    return (int(matches[0]), int(matches[1]))
+    file_path = key.split('/')
+    dump_id = file_path[0].replace('sync_', '')
+    part_number = re.findall('([0-9]+)', file_path[-1])[0]
+    return (int(dump_id), int(part_number))
 
 def get_files_to_sync(table_manifests, table_name, state, bucket):
     bookmark = singer.get_bookmark(state, table_name, 'file')

--- a/tap_heap/sync.py
+++ b/tap_heap/sync.py
@@ -95,9 +95,10 @@ def sync_stream(bucket, state, stream, manifests):
         state = singer.write_bookmark(state, table_name, 'file', s3_file_path)
         singer.write_state(state)
 
-    LOGGER.info('Sending activate version message %d', version)
-    message = singer.ActivateVersionMessage(stream=table_name, version=version)
-    singer.write_message(message)
+    if records_streamed > 0:
+        LOGGER.info('Sending activate version message %d', version)
+        message = singer.ActivateVersionMessage(stream=table_name, version=version)
+        singer.write_message(message)
 
     LOGGER.info('Wrote %s records for table "%s".', records_streamed, table_name)
     return records_streamed

--- a/tap_heap/sync.py
+++ b/tap_heap/sync.py
@@ -55,7 +55,7 @@ def get_files_to_sync(table_manifests, table_name, state, bucket):
                     for manifest in table_manifests.values()
                     for file_name in manifest['files']])
 
-    if bookmark and bookmarked_version:
+    if bookmark and bookmarked_version and bookmark in files:
         #NB> The bookmark is a fully synced file, so start immediately
         #after the bookmark
         files = files[files.index(bookmark)+1:]

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -159,31 +159,43 @@ class TestGetFilesToSync(unittest.TestCase):
     def setUp(self):
         """Note: `fileX` here would look like `"sync_123/table1/part_00013/GUID.avro"`"""
         self.manifests = {
-            123: {"files": ["s3://bucket1/file1", "s3://bucket1/file2", "s3://bucket1/file3"],
+            123: {"files": ["s3://bucket1/sync_123/file1", "s3://bucket1/sync_123/file2", "s3://bucket1/sync_123/file3"],
                   "incremental": False,
                   "columns": ["column1", "column2", "column3"]},
-            124: {"files": ["s3://bucket1/file4", "s3://bucket1/file5", "s3://bucket1/file6"],
+            124: {"files": ["s3://bucket1/sync_123/file4", "s3://bucket1/sync_123/file5", "s3://bucket1/sync_123/file6"],
                   "incremental": True,
                   "columns": ["column1", "column2", "column3"]},
-            125: {"files": ["s3://bucket1/file7", "s3://bucket1/file8", "s3://bucket1/file9"],
+            125: {"files": ["s3://bucket1/sync_123/file7", "s3://bucket1/sync_123/file8", "s3://bucket1/sync_123/file9"],
                   "incremental": True,
                   "columns": ["column1", "column2", "column3"]},
         }
         self.maxDiff = None
 
     def test_no_bookmark(self):
-        expected_value = ["file1", "file2", "file3", "file4", "file5", "file6", "file7", "file8", "file9"]
+        expected_value = ["sync_123/file1",
+                          "sync_123/file2",
+                          "sync_123/file3",
+                          "sync_123/file4",
+                          "sync_123/file5",
+                          "sync_123/file6",
+                          "sync_123/file7",
+                          "sync_123/file8",
+                          "sync_123/file9"]
         state = {}
         actual_value = get_files_to_sync(self.manifests, "table1", state, "bucket1")
 
         self.assertListEqual(expected_value, actual_value)
 
     def test_has_bookmark(self):
-        expected_value = ["file5", "file6", "file7", "file8", "file9"]
+        expected_value = ["sync_123/file5",
+                          "sync_123/file6",
+                          "sync_123/file7",
+                          "sync_123/file8",
+                          "sync_123/file9"]
         state = {
             "bookmarks": {
                 "table1": {
-                    "file": "file4",
+                    "file": "sync_123/file4",
                     "version": 1607032341846
                 }
             }


### PR DESCRIPTION
# Description of change
 - Only send activate version if we sent records
 - Only filter files on the bookmark if the bookmark is in the files list
 - Sort the files explicitly using the dump id and part number instead of using string sorting

# Manual QA steps
 - Ran on a connection and ensured these issues did not happen
 
# Risks

 
# Rollback steps
 - revert this branch
