### PR TITLE
limit setuptools version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: |
             python3 -m venv ~/.virtualenvs/tap-heap
             source ~/.virtualenvs/tap-heap/bin/activate
-            pip install -U pip setuptools
+            pip install -U 'pip<19.2' 'setuptools<51.0.0'
             pip install .[dev]
       - run:
           name: 'Run tests'


### PR DESCRIPTION
# Description of change
Limit setuptools version so that env will source and tests can run.

# Manual QA steps
 - None
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
