### PR TITLE
Handle non-union types in Avro schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.1.4
+  * Handle non-union Avro types correctly during sync [#18](https://github.com/singer-io/tap-heap/pull/18)
+
 # 1.1.3
   * Only send activate version if we sent records
   * Only filter files on the bookmark if the bookmark is in the files list

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-heap',
-      version='1.1.3',
+      version='1.1.4',
       description='Singer.io tap for extracting Heap data from Avro files in S3',
       author='Stitch',
       url='https://singer.io',

--- a/tap_heap/schema.py
+++ b/tap_heap/schema.py
@@ -20,6 +20,9 @@ def generate_schema_from_avro(avro_schema):
 def translate_avro_type(avro_type):
     translated_type = ["null"]
 
+    if isinstance(avro_type, str):
+        avro_type = [avro_type]
+
     for typ in avro_type:
         if typ == "null":
             continue

--- a/tap_heap/schema.py
+++ b/tap_heap/schema.py
@@ -18,13 +18,14 @@ def generate_schema_from_avro(avro_schema):
 
 
 def translate_avro_type(avro_type):
-    translated_type = ["null"]
+    translated_type = []
 
     if isinstance(avro_type, str):
         avro_type = [avro_type]
 
     for typ in avro_type:
         if typ == "null":
+            translated_type.append("null")
             continue
 
         if typ in ["int", "long"]:


### PR DESCRIPTION
# Description of change
Avro can have a non-union type for a `type`, this can manifest as a single string type rather than a list. This resulted in the followng error (e.g., for a type of `"long"`):

```
Encountered an Avro type that is not supported in JSON Schema: l
```

# Manual QA steps
 - Ran through with a connection that was receiving the error to verify that this was the case directly and confirmed it moves forward with this change.
 
# Risks
 - Low, this is a pretty clear reason and change
 
# Rollback steps
 - revert this branch, release new patch version
