### PR TITLE
Enable AWS access key as alternative auth method

### DIFF
--- a/tap_heap/s3.py
+++ b/tap_heap/s3.py
@@ -42,6 +42,14 @@ class AssumeRoleProvider():
 
 @retry_pattern()
 def setup_aws_client(config):
+    if config.get("aws_access_key_id") and config.get("aws_secret_access_key"):
+        LOGGER.info("Using AWS access keys for auth")
+        boto3.setup_default_session(
+            aws_access_key_id=config.get("aws_access_key_id"),
+            aws_secret_access_key=config.get("aws_secret_access_key"),
+        )
+        return
+
     role_arn = "arn:aws:iam::{}:role/{}".format(config['account_id'].replace('-', ''),
                                                 config['role_name'])
     session = Session()


### PR DESCRIPTION
# Description of change
Previously this only allowed for IAM role access to the s3 bucket.
This commit allows for an alternative, with s3 access coming from an
account via providing aws_access_key_id and aws_secret_access_key to
the config. If access key pair is provided, it overrides an IAM role
information provided.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
