### PR TITLE
adds credentials_cache_path property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.0
+  * Changes JSONFileCache location [#22](https://github.com/singer-io/tap-heap/pull/22)
+
 ## 1.3.0
   * Adds proxy AWS Account support
   * [#21](https://github.com/singer-io/tap-heap/pull/21)

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,11 @@ setup(name='tap-heap',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_heap'],
       install_requires=[
-          'boto3==1.34.117',
+          'boto3==1.39.9',
           'singer-encodings==0.1.3',
-          'singer-python==6.0.1',
-          'python-snappy==0.7.1',
-          'fastavro==1.9.4'
+          'singer-python==6.1.1',
+          'python-snappy==0.7.3',
+          'fastavro==1.11.1'
       ],
       extras_require={
           'dev': [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-heap',
-      version='1.3.0',
+      version='1.4.0',
       description='Singer.io tap for extracting Heap data from Avro files in S3',
       author='Stitch',
       url='https://singer.io',

--- a/tap_heap/s3.py
+++ b/tap_heap/s3.py
@@ -73,7 +73,7 @@ def setup_aws_client_with_proxy(config):
     # pylint: disable=line-too-long
     proxy_role_arn = f"arn:aws:iam::{config['proxy_account_id'].replace('-', '')}:role/{config['proxy_role_name']}"
     cust_role_arn = f"arn:aws:iam::{config['account_id'].replace('-', '')}:role/{config['role_name']}"
-
+    credentials_cache_path = config.get("credentials_cache_path", JSONFileCache.CACHE_DIR)
     # Step 1: Assume Role in Account Proxy and set up refreshable session
     session_proxy = Session()
     fetcher_proxy = AssumeRoleCredentialFetcher(
@@ -84,7 +84,7 @@ def setup_aws_client_with_proxy(config):
             'DurationSeconds': 3600,
             'RoleSessionName': 'ProxySession'
         },
-        cache=JSONFileCache()
+        cache=JSONFileCache(credentials_cache_path)
     )
 
     # Refreshable credentials for Account Proxy
@@ -105,7 +105,7 @@ def setup_aws_client_with_proxy(config):
             'RoleSessionName': 'TapHeapCustSession',
             'ExternalId': config['external_id']
         },
-        cache=JSONFileCache()
+        cache=JSONFileCache(credentials_cache_path)
     )
 
     # Set up refreshable session for Customer Account


### PR DESCRIPTION
# Description of change
Adds `credentials_cache_path` property to customize where the JSONFileCache is stored.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
