### PR TITLE
SAC-30244: Standardize State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.0.0
+## 1.5.0
   * Update state reads/writes to move `version` out of the `bookmarks` key and into a top-level `activate_versions` key in state. [#28](https://github.com/singer-io/tap-heap/pull/28)
 
 ## 1.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.5.0
-  * Update state reads/writes to move `version` out of the `bookmarks` key and into a top-level `activate_versions` key in state. [#28](https://github.com/singer-io/tap-heap/pull/28)
+  * Update state reads/writes to move `version` out of the `bookmarks` key and into a top-level `versions` key in state. [#28](https://github.com/singer-io/tap-heap/pull/28)
 
 ## 1.4.1
   * Allows the use of --catalog as opposed to just --properties [#24](https://github.com/singer-io/tap-heap/pull/24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.0
+  * Update state reads/writes to move `version` out of the `bookmarks` key and into a top-level `activate_versions` key in state. [#28](https://github.com/singer-io/tap-heap/pull/28)
+
 ## 1.4.1
   * Allows the use of --catalog as opposed to just --properties [#24](https://github.com/singer-io/tap-heap/pull/24)
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='tap-heap',
       install_requires=[
           'boto3==1.39.9',
           'singer-encodings==0.1.3',
-          'singer-python==6.7.0',
+          'singer-python==6.8.0',
           'python-snappy==0.7.3',
           'fastavro==1.11.1'
       ],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-heap',
-      version='1.4.1',
+      version='2.0.0',
       description='Singer.io tap for extracting Heap data from Avro files in S3',
       author='Stitch',
       url='https://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-heap',
-      version='2.0.0',
+      version='1.5.0',
       description='Singer.io tap for extracting Heap data from Avro files in S3',
       author='Stitch',
       url='https://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='tap-heap',
       install_requires=[
           'boto3==1.39.9',
           'singer-encodings==0.1.3',
-          'singer-python==6.1.1',
+          'singer-python==6.7.0',
           'python-snappy==0.7.3',
           'fastavro==1.11.1'
       ],

--- a/tap_heap/__init__.py
+++ b/tap_heap/__init__.py
@@ -65,9 +65,11 @@ def do_sync(config, catalog, state):
 
 
 def transform_state(state):
+    '''Removes the `version` key from bookmarks and adds it to a new top-level
+    `activate_versions` key in state'''
     bookmarks = state.get('bookmarks', {})
-    for tap_stream_id, stream_bookmarks in bookmarks.items():
-        if version := stream_bookmarks.get('version'):
+    for tap_stream_id in bookmarks:
+        if version := singer.get_bookmark(state, tap_stream_id, 'version'):
             state = singer.set_version(state, tap_stream_id, version)
             state = singer.clear_bookmark(state, tap_stream_id, 'version')
     return state

--- a/tap_heap/__init__.py
+++ b/tap_heap/__init__.py
@@ -64,6 +64,15 @@ def do_sync(config, catalog, state):
     LOGGER.info('Done syncing.')
 
 
+def transform_state(state):
+    bookmarks = state.get('bookmarks', {})
+    for tap_stream_id, stream_bookmarks in bookmarks.items():
+        if version := stream_bookmarks.get('version'):
+            state = singer.set_version(state, tap_stream_id, version)
+            state = singer.clear_bookmark(state, tap_stream_id, 'version')
+    return state
+
+
 @singer.utils.handle_top_exception(LOGGER)
 def main():
     args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
@@ -92,9 +101,9 @@ def main():
     if args.discover:
         do_discover(args.config)
     elif args.properties:
-        do_sync(args.config, args.properties, args.state)
+        do_sync(args.config, args.properties, transform_state(args.state))
     elif args.catalog:
-        do_sync(args.config, args.catalog.to_dict(), args.state)
+        do_sync(args.config, args.catalog.to_dict(), transform_state(args.state))
 
 if __name__ == '__main__':
     main()

--- a/tap_heap/__init__.py
+++ b/tap_heap/__init__.py
@@ -66,7 +66,7 @@ def do_sync(config, catalog, state):
 
 def transform_state(state):
     '''Removes the `version` key from bookmarks and adds it to a new top-level
-    `activate_versions` key in state'''
+    `versions` key in state'''
     bookmarks = state.get('bookmarks', {})
     for tap_stream_id in bookmarks:
         if version := singer.get_bookmark(state, tap_stream_id, 'version'):

--- a/tap_heap/sync.py
+++ b/tap_heap/sync.py
@@ -34,7 +34,7 @@ def filter_manifests_to_sync(manifests, table_name, state):
 
     bookmark = singer.get_bookmark(state, table_name, 'file')
     # bookmark = "sync_{DUMP_ID}/{TABLE_NAME}/part-00016-{GUID}.avro"
-    bookmarked_version = singer.get_bookmark(state, table_name, 'version')
+    bookmarked_version = singer.get_version(state, table_name)
     if bookmark and bookmarked_version:
         bookmarked_dump_id = int(bookmark.split('/')[0].replace('sync_', ''))
 
@@ -78,7 +78,7 @@ def key_fn(key):
 
 def get_files_to_sync(table_manifests, table_name, state, bucket):
     bookmark = singer.get_bookmark(state, table_name, 'file')
-    bookmarked_version = singer.get_bookmark(state, table_name, 'version')
+    bookmarked_version = singer.get_version(state, table_name)
 
     # Get flattened file names and remove the prefix
     files = sorted([remove_prefix(file_name, bucket)
@@ -118,7 +118,7 @@ def sync_stream(bucket, state, stream, manifests, batch_size=5):    # pylint: di
 
     records_streamed = 0
 
-    version = singer.get_bookmark(state, table_name, 'version')
+    version = singer.get_version(state, table_name)
 
     if should_create_new_version:
         # Set version so it can be used for an activate version message
@@ -127,7 +127,7 @@ def sync_stream(bucket, state, stream, manifests, batch_size=5):    # pylint: di
         LOGGER.info('Detected full sync for stream table name %s, setting version to %d',
                     table_name,
                     version)
-        state = singer.write_bookmark(state, table_name, 'version', version)
+        state = singer.set_version(state, table_name, version)
         singer.write_state(state)
 
     with futures.ProcessPoolExecutor(max_workers=batch_size) as executor:

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -49,6 +49,7 @@ class TapHeapBookmarksTest(TapHeapBaseCase):
 
         state = menagerie.get_state(conn_id)
         self.assertNotEqual(state or {}, {}, f'the state should not be empty {state}')
+        self.assertTrue(state.get('activate_versions') is not None)
 
         # Run another Sync
         sync_job_name = runner.run_sync_mode(self, conn_id)

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -49,7 +49,7 @@ class TapHeapBookmarksTest(TapHeapBaseCase):
 
         state = menagerie.get_state(conn_id)
         self.assertNotEqual(state or {}, {}, f'the state should not be empty {state}')
-        self.assertTrue(state.get('activate_versions') is not None)
+        self.assertTrue(state.get('versions') is not None)
 
         # Run another Sync
         sync_job_name = runner.run_sync_mode(self, conn_id)

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -93,8 +93,10 @@ class TestFilterManifests(unittest.TestCase):
             "bookmarks": {
                 "table1": {
                     "file": "sync_124/table1/part-00001-GUID.avro",
-                    "version": 1607032341846
                 }
+            },
+            "activate_versions": {
+                "table1": 1607032341846
             }
         }
         actual_value = filter_manifests_to_sync(self.manifests, "table1", state)
@@ -118,8 +120,10 @@ class TestFilterManifests(unittest.TestCase):
             "bookmarks": {
                 "table1": {
                     "file": "sync_124/table1/part-00001-GUID.avro",
-                    "version": 1607032341846
                 }
+            },
+            "activate_versions": {
+                "table1": 1607032341846
             }
         }
         actual_value = filter_manifests_to_sync(self.manifests, "table1", state)
@@ -145,8 +149,10 @@ class TestFilterManifests(unittest.TestCase):
             "bookmarks": {
                 "table1": {
                     "file": "sync_124/table1/part-00001-GUID.avro",
-                    "version": 1607032341846
                 }
+            },
+            "activate_versions": {
+                "table1": 1607032341846
             }
         }
         actual_value = filter_manifests_to_sync(self.manifests, "table1", state)
@@ -196,8 +202,10 @@ class TestGetFilesToSync(unittest.TestCase):
             "bookmarks": {
                 "table1": {
                     "file": "sync_123/file4",
-                    "version": 1607032341846
                 }
+            },
+            "activate_versions": {
+                "table1": 1607032341846
             }
         }
         actual_value = get_files_to_sync(self.manifests, "table1", state, "bucket1")

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -95,7 +95,7 @@ class TestFilterManifests(unittest.TestCase):
                     "file": "sync_124/table1/part-00001-GUID.avro",
                 }
             },
-            "activate_versions": {
+            "versions": {
                 "table1": 1607032341846
             }
         }
@@ -122,7 +122,7 @@ class TestFilterManifests(unittest.TestCase):
                     "file": "sync_124/table1/part-00001-GUID.avro",
                 }
             },
-            "activate_versions": {
+            "versions": {
                 "table1": 1607032341846
             }
         }
@@ -151,7 +151,7 @@ class TestFilterManifests(unittest.TestCase):
                     "file": "sync_124/table1/part-00001-GUID.avro",
                 }
             },
-            "activate_versions": {
+            "versions": {
                 "table1": 1607032341846
             }
         }
@@ -204,7 +204,7 @@ class TestGetFilesToSync(unittest.TestCase):
                     "file": "sync_123/file4",
                 }
             },
-            "activate_versions": {
+            "versions": {
                 "table1": 1607032341846
             }
         }


### PR DESCRIPTION
# Description of change
Update state reads/writes to move `version` out of `bookmarks` and into a top-level `activate_versions` in `state`.

# Manual QA steps
 - Verified `version` is no longer under the `bookmarks` key
 
# Risks
 - Anything expecting state to output `version` under the `bookmarks` key will be broken by this change
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
